### PR TITLE
Fix/notify startdiscovery failure

### DIFF
--- a/android/src/main/kotlin/com/nimroddayan/flutternsd/FlutterNsdPlugin.kt
+++ b/android/src/main/kotlin/com/nimroddayan/flutternsd/FlutterNsdPlugin.kt
@@ -115,6 +115,9 @@ class FlutterNsdPlugin : FlutterPlugin, MethodCallHandler {
             nsdManager?.discoverServices(serviceType, NsdManager.PROTOCOL_DNS_SD, discoveryListener)
         } catch (ex: Exception) {
             Timber.w("Cannot start, NSD is already running")
+            mainHandler.post {
+                channel.invokeMethod("onStartDiscoveryFailed", null);
+            }
         }
     }
 

--- a/ios/Classes/SwiftFlutterNsdPlugin.swift
+++ b/ios/Classes/SwiftFlutterNsdPlugin.swift
@@ -56,6 +56,10 @@ public class SwiftFlutterNsdPlugin: NSObject, FlutterPlugin, NetServiceBrowserDe
         }
     }
 
+    public func netServiceBrowser(_ browser: NetServiceBrowser, didNotSearch errorDict: [String : NSNumber]) {
+        channel.invokeMethod("onStartDiscoveryFailed", arguments: nil);
+    }
+
     public func netServiceBrowserDidStopSearch(_ browser: NetServiceBrowser) {
         channel.invokeMethod("onDiscoveryStopped", arguments: nil);
         netServiceBrowser.delegate = nil

--- a/ios/Classes/SwiftFlutterNsdPlugin.swift
+++ b/ios/Classes/SwiftFlutterNsdPlugin.swift
@@ -44,7 +44,6 @@ public class SwiftFlutterNsdPlugin: NSObject, FlutterPlugin, NetServiceBrowserDe
     }
 
     private func stopDiscovery() {
-        netServiceBrowser.delegate = nil
         netServiceBrowser.stop()
     }
 
@@ -55,6 +54,11 @@ public class SwiftFlutterNsdPlugin: NSObject, FlutterPlugin, NetServiceBrowserDe
                 service.resolve(withTimeout: 10)
             }
         }
+    }
+
+    public func netServiceBrowserDidStopSearch(_ browser: NetServiceBrowser) {
+        channel.invokeMethod("onDiscoveryStopped", arguments: nil);
+        netServiceBrowser.delegate = nil
     }
 
     public func netServiceBrowser(_ browser: NetServiceBrowser, didFind service: NetService, moreComing: Bool) {

--- a/lib/flutter_nsd.dart
+++ b/lib/flutter_nsd.dart
@@ -70,6 +70,9 @@ class FlutterNsd {
           ));
           break;
         case 'onDiscoveryStopped':
+          _streamController.addError(NsdError(
+            errorCode: NsdErrorCode.discoveryStopped,
+          ));
           _channel.setMethodCallHandler(null);
           break;
         case 'onServiceResolved':
@@ -106,6 +109,7 @@ enum NsdErrorCode {
   startDiscoveryFailed,
   stopDiscoveryFailed,
   onResolveFailed,
+  discoveryStopped,
 }
 
 // Generic error thrown when an error has occurred during discovery

--- a/lib/flutter_nsd.dart
+++ b/lib/flutter_nsd.dart
@@ -55,13 +55,19 @@ class FlutterNsd {
     _channel.setMethodCallHandler((MethodCall call) async {
       switch (call.method) {
         case 'onStartDiscoveryFailed':
-          _streamController.addError(NsdError());
+          _streamController.addError(NsdError(
+            errorCode: NsdErrorCode.startDiscoveryFailed,
+          ));
           break;
         case 'onStopDiscoveryFailed':
-          _streamController.addError(NsdError());
+          _streamController.addError(NsdError(
+            errorCode: NsdErrorCode.stopDiscoveryFailed,
+          ));
           break;
         case 'onResolveFailed':
-          _streamController.addError(NsdError());
+          _streamController.addError(NsdError(
+            errorCode: NsdErrorCode.onResolveFailed,
+          ));
           break;
         case 'onDiscoveryStopped':
           _channel.setMethodCallHandler(null);
@@ -95,5 +101,17 @@ class NsdServiceInfo {
   NsdServiceInfo(this.hostname, this.port, this.name, this.txt);
 }
 
+/// List of possible error codes of NsdError
+enum NsdErrorCode {
+  startDiscoveryFailed,
+  stopDiscoveryFailed,
+  onResolveFailed,
+}
+
 // Generic error thrown when an error has occurred during discovery
-class NsdError extends Error {}
+class NsdError extends Error {
+  /// The cause of this [NsdError].
+  final NsdErrorCode errorCode;
+
+  NsdError({required this.errorCode});
+}


### PR DESCRIPTION
This adds the required bits and pieces to detect when `discoverServices()` fails, i.e. after a flutter hot-restart where the discovery backend is still running, but the plugin is not properly bound to it anymore.

In order to gracefully recover from this a stop->start cycle needs to be done, for which the app actually needs to know when `stopDiscovery()` did actualy finish, for which an error code is added.

Fixes #3